### PR TITLE
Parralel tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
     - 'config/initializers/simple_form_bootstrap.rb'
     - 'config/initializers/devise.rb'
     - 'config/environments/production.rb'
+    - 'config/spring.rb'
     - 'lib/builders/bootstrap_breadcrumbs_builder.rb'
     - 'node_modules/**/*'
     - 'bin/webpack'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'faker'
   gem 'rspec-rails', '~> 3.7'
   gem 'selenium-webdriver'
+  gem 'parallel_tests'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,8 @@ GEM
       shellany (~> 0.0)
     orm_adapter (0.5.0)
     parallel (1.12.1)
+    parallel_tests (2.29.0)
+      parallel
     parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (0.18.4)
@@ -429,6 +431,7 @@ DEPENDENCIES
   mini_magick
   momentjs-rails
   net-ldap
+  parallel_tests
   pg (= 0.18.4)
   puma (~> 3.7)
   rails (~> 5.2.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: sgtcc_test
+  database: sgtcc_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *default

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,3 +1,25 @@
+require 'spring/application'
+
+class Spring::Application
+  alias connect_database_orig connect_database
+
+  # Disconnect & reconfigure to pickup DB name with
+  # TEST_ENV_NUMBER suffix
+  def connect_database
+    disconnect_database
+    reconfigure_database
+    connect_database_orig
+  end
+
+  # Here we simply replace existing AR from main spring process
+  def reconfigure_database
+    if active_record_configured?
+      ActiveRecord::Base.configurations =
+        Rails.application.config.database_configuration
+    end
+  end
+end
+
 %w[
   .ruby-version
   .rbenv-vars

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,6 @@
+Capybara.configure do |config|
+  config.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+end
 Capybara.register_driver :firefox_headless do |app|
   options = ::Selenium::WebDriver::Firefox::Options.new
   options.args << '--headless'


### PR DESCRIPTION
change on config/database.yml

```
test:
  database: yourproject_test<%= ENV['TEST_ENV_NUMBER'] %>
```
```
rails parallel:create
```
```
rails parallel:prepare
```
```
rails parallel:spec
```
By default, parallel_tests will set it to number of CPUs available (i.e. 4 cores with hyperthreading, will count as 8 cores). If You would like to override it, append [<no of processors to run>] to tasks below or better, export environment variable to have it the same for all the tasks, i.e.
```
export PARALLEL_TEST_PROCESSORS=8 
```
Just remember to put it in something like .bashrc or .env file, in order to have it always loaded between sessions.